### PR TITLE
fail-safe image URLs if CloudImage is not configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You will need to sign up to some external API providers:
 * Flickr Import requires a [Flickr API key](https://www.flickr.com/services/api/)
 * Tweeting requires a [Twitter Developer API key](https://apps.twitter.com/)
 * Text detection requires a [Google Cloud Vision API key](https://cloud.google.com/vision/)
-* Image resizing and caching requires a [CloudImage.io account](https://www.cloudimage.io)
+* Image resizing and caching requires a [CloudImage.io account](https://www.cloudimage.io). (But note: this requires your development webserver to be accessible from the internet)
 * **Optional** Login requires a free [Auth0.com](https://auth0.com/) account.
 
 Add them to `config.php.example` - rename that to `config.php`

--- a/www/functions.php
+++ b/www/functions.php
@@ -489,6 +489,9 @@ function duplicate_file($filename) {
 
 function get_image_cache($size=IMAGE_DEFAULT_SIZE, $filter=IMAGE_DEFAULT_FILTER) {
 	//	Generate a prefix for the cached image. Can be thumbnailed. https://docs.cloudimage.io/go/cloudimage-documentation/en/operations/
+	if (IMAGE_CACHE_PREFIX == "") {
+		return "";
+	}
 	return IMAGE_CACHE_PREFIX . "{$size}/$filter/" . $_SERVER['SERVER_NAME'];
 }
 


### PR DESCRIPTION
# Issue

When doing local development, some images fail to render if CloudImage is not fully configured. See issue #203.

# Change

This change:

* returns an empty string from `get_image_cache` if `IMAGE_CACHE_PREFIX` is unset. This results in image URLs which point to the _OpenBenches_ webserver instead of CloudImage
* adds note to `README` about CloudImage needing to have access to the _OpenBenches_ webserver