### PR TITLE
disable clustering at high zooms

### DIFF
--- a/www/functions.php
+++ b/www/functions.php
@@ -300,7 +300,8 @@ function get_map_javascript($lat = "54.5", $long="-4", $zoom = "5") {
 	L.control.layers(baseMaps).addTo(map);
 
 	var markers = L.markerClusterGroup({
-		maxClusterRadius: 29
+		maxClusterRadius: 29,
+		disableClusteringAtZoom: 17
 	});
 </script>
 EOT;


### PR DESCRIPTION
Makes it easier to see different benches when they are close together :)
(clustering is disabled on z17 and higher)

before:
<img width="559" src="https://user-images.githubusercontent.com/26939824/164998180-05f95a78-850d-4f28-b622-d98dce2ff905.png">
after:
<img width="559" src="https://user-images.githubusercontent.com/26939824/164998513-35f124da-841a-4165-9e10-a37bb0cba65c.png">

fixes #253

Signed-off-by: Harry Bond <endim8@pm.me>