### PR TITLE
#290 re-enable saving of tags when benches are added

### DIFF
--- a/www/upload.php
+++ b/www/upload.php
@@ -87,9 +87,9 @@ if ($_FILES['userfile1']['tmp_name'])
 				$mediaFiles[] = get_path_from_hash($sha1,true);
 			}
 
-			// if (!empty($tags)){
-			// 	save_tags($benchID, $tags);
-			// }
+			 if (!empty($tags)){
+			 	save_tags($benchID, $tags);
+			 }
 
 			//	Drop us an email
 			$key = urlencode(get_edit_key($benchID));


### PR DESCRIPTION
I'm assuming that disabling of tags being saved was accidental so here's a PR to re-enable it.