### PR TITLE
#265 enable editing of tags

### DIFF
--- a/www/bench.php
+++ b/www/bench.php
@@ -57,7 +57,7 @@ if (!$present) {
 			echo    "<li class='pseudo button'>Tags:</li>";
 
 			foreach ($tags as $tag) {
-				echo "<li class='pseudo button'><a href='/tag/{$tag}/'>#{$tag}</a></li>";
+				echo "<li class='pseudo button'><a href='/tag/{$tag['tagText']}/'>#{$tag['tagText']}</a></li>";
 			}
 			echo "</ul>";
 		}

--- a/www/mysql.php
+++ b/www/mysql.php
@@ -1630,16 +1630,30 @@ function get_bench_tag_count($tagText) {
 	return $count;
 }
 
-function save_tags($benchID, $tags) {
-	global $mysqli;
 
-	foreach ($tags as $tagID) {
-		$save_tag = $mysqli->prepare(
-			"INSERT INTO `tag_map` (`mapID`, `benchID`, `tagID`)
-			VALUES                 (NULL,     ?,         ?)");
-		$save_tag->bind_param('ii', $benchID, $tagID);
-		$save_tag->execute();
-		$save_tag->close();
+function save_tags($benchID, $tags) {
+	// this function needs to work for when a bench is added or edited
+	// when a bench is edited that may mean that the number of tags
+	// increases, or decreases to as few as zero
+	// easiest way to deal with this is to remove all entries for the
+	// bench then add whatever tags were passed
+	global $mysqli;
+	$mysqli->begin_transaction();
+	try {
+		$remove_tags = $mysqli->prepare("DELETE FROM `tag_map` WHERE `benchID`=$benchID");
+		$remove_tags->execute();
+		$remove_tags->close();
+		foreach ($tags as $tagID) {
+			$save_tag = $mysqli->prepare(
+				"INSERT INTO `tag_map` (`mapID`, `benchID`, `tagID`)
+				VALUES                 (NULL,     ?,         ?)");
+			$save_tag->bind_param('ii', $benchID, $tagID);
+			$save_tag->execute();
+			$save_tag->close();
+		}
+		$mysqli->commit();
+	} catch (mysqli_sql_exception $exception) {
+		$mysqli->rollback();
 	}
 	return true;
 }
@@ -1648,17 +1662,17 @@ function get_tags_from_bench($benchID) {
 	global $mysqli;
 
 	$get_tags = $mysqli->prepare(
-		"SELECT tags.tagText
+		"SELECT tags.tagText, tags.tagID
 		 FROM `tag_map`
 		 INNER JOIN tags ON (tags.`tagID` = tag_map.`tagID`)
 		 WHERE `benchID` = ?");
 	$get_tags->bind_param('i', $benchID);
 	$get_tags->execute();
-	$get_tags->bind_result($tag);
+	$get_tags->bind_result($tag, $tagID);
 
 	$tags = array();
 	while($get_tags->fetch()) {
-		$tags[] = $tag;
+		$tags[] = array("tagText"=>$tag, "tagID"=>$tagID);
 	}
 
 	$get_tags->close();

--- a/www/mysql.php
+++ b/www/mysql.php
@@ -1640,7 +1640,8 @@ function save_tags($benchID, $tags) {
 	global $mysqli;
 	$mysqli->begin_transaction();
 	try {
-		$remove_tags = $mysqli->prepare("DELETE FROM `tag_map` WHERE `benchID`=$benchID");
+		$remove_tags = $mysqli->prepare("DELETE FROM `tag_map` WHERE `benchID`=?");
+		$remove_tags->bind_param('i', $benchID);
 		$remove_tags->execute();
 		$remove_tags->close();
 		foreach ($tags as $tagID) {

--- a/www/upload.php
+++ b/www/upload.php
@@ -87,9 +87,9 @@ if ($_FILES['userfile1']['tmp_name'])
 				$mediaFiles[] = get_path_from_hash($sha1,true);
 			}
 
-			// if (!empty($tags)){
-			// 	save_tags($benchID, $tags);
-			// }
+			 if (!empty($tags)){
+			 	save_tags($benchID, $tags);
+			 }
 
 			//	Drop us an email
 			$key = urlencode(get_edit_key($benchID));


### PR DESCRIPTION
Allows editing of tags on the bench edit page.

Modifies `get_tags_from_bench()` to include tag ids. This allows what it returns to be used with select2. 

Modifies the only pre-existing use of `get_tags_from_bench()` output in `benches.php` to account for this. 

Modifies `save_benches()` to first delete all tags for the bench then add whatever tags are passed. I believe I've done this such that the deletion and adding cannot succeed or fail independently of each other, which avoids scenarios such as all the tags are deleted but then the new set of tags aren't added, or the deletion fails but the new set of tags is added and now the bench has multiple instances of one or more tags.

Adds information about old and new tags to the email sent to administrator.

Tested for:
 - Adding N tags,
 - Removing N tags
 - Removing all tags.


This PR assumes that the disabling of the call to `save_tags` in `upload.php` mentioned in #290 was a mistake and makes https://github.com/openbenches/openbenches.org/pull/292 redundant. 

I always use two spaces for indentation and found myself making concious effort to try to adhere to the existing use of tabs for indentation in the code, but maybe I've failed somewhere.